### PR TITLE
Adding wifi mode set to prevent erroneous SSID broadcast from ESP8266.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -306,6 +306,7 @@ bool parseRoombaStateFromStreamPacket(uint8_t *packet, int length, RoombaState *
         break;
     }
   }
+  return false;
 }
 
 void verboseLogPacket(uint8_t *packet, uint8_t length) {
@@ -357,6 +358,7 @@ void setup() {
   String hostname(HOSTNAME);
   WiFi.hostname(hostname);
   WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  WiFi.mode(WIFI_STA);
 
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);


### PR DESCRIPTION
Current version occasionally broadcasts an AP with SSID "ESP_[MAC]" with no password.  Per this issue on the esp8266 Arduino library, fix is to set the Wifi mode *after* Wifi.begin:
https://github.com/esp8266/Arduino/issues/549

Also one additional return statement to fix compiler warning about non-void function.